### PR TITLE
Switch submodule remote url to https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "dependencies/rosserial"]
 	path = dependencies/rosserial
-	url = git@github.com:ethz-asl/rosserial.git
+	url = https://github.com/ethz-asl/rosserial.git
 [submodule "dependencies/versavis_hw"]
 	path = dependencies/versavis_hw
-	url = git@github.com:ethz-asl/versavis_hw.git
+	url = https://github.com/ethz-asl/versavis_hw.git


### PR DESCRIPTION
**Problem Description**
When cloning this repository through the https protocol, it is unable to properly parse the submodules unless the ssh keys are available. This is an issue e.g. when pulling the repo from a CI instance/vehicle where an ssh key might not be present.

**Solution**
This commit switches the submodule remote url to https, in order to help making it work with the https protocol.
Since the submodules are public, I think this would not introduce any issues with the users using the ssh url