### PR TITLE
Add build tests for different ROS versions

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,0 +1,41 @@
+name: Build Test
+on:
+  push:
+    branches:
+    - 'master'
+  pull_request:
+    branches:
+    - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {rosdistro: 'melodic', container: 'px4io/px4-dev-ros-melodic:2020-08-14'}
+          - {rosdistro: 'noetic', container: 'px4io/px4-dev-ros-noetic:2020-08-20'}
+    container: ${{ matrix.config.container }}
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        token: ${{ secrets.ACCESS_TOKEN }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: release_build_test
+      working-directory: 
+      run: |
+        apt update
+        apt install -y python3-wstool
+        mkdir -p $HOME/catkin_ws/src;
+        cd $HOME/catkin_ws
+        catkin init
+        catkin config --extend "/opt/ros/${{matrix.config.rosdistro}}"
+        catkin config --merge-devel
+        cd $HOME/catkin_ws/src
+        ln -s $GITHUB_WORKSPACE
+        cd $HOME/catkin_ws
+        rosdep update
+        rosdep install --from-paths src --ignore-src -y --rosdistro ${{matrix.config.rosdistro}}
+        catkin config --cmake-args -DCMAKE_BUILD_TYPE=Release -DCATKIN_ENABLE_TESTING=False
+        catkin build -j$(nproc) -l$(nproc) versavis

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -15,19 +15,29 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {rosdistro: 'melodic', container: 'px4io/px4-dev-ros-melodic:2020-08-14'}
-          - {rosdistro: 'noetic', container: 'px4io/px4-dev-ros-noetic:2020-08-20'}
+          - {rosdistro: 'melodic', container: 'ros:melodic-ros-base-bionic'}
+          - {rosdistro: 'noetic', container: 'ros:noetic-ros-base-focal'}
     container: ${{ matrix.config.container }}
     steps:
     - uses: actions/checkout@v1
       with:
         token: ${{ secrets.ACCESS_TOKEN }}
         github-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Install catkin-tools on melodic
+      if: ${{ matrix.config.container == 'ros:melodic-ros-base-bionic' }}
+      run: |
+        apt update && apt install -y python3-wstool python-catkin-tools 
+    - name: Install catkin-tools on Noetic
+      if: ${{ matrix.config.container == 'ros:noetic-ros-base-focal' }}
+      run: |
+        apt update && apt install -y python3-pip
+        pip3 install osrf-pycommon
+        apt update && apt install -y python3-wstool python3-catkin-tools 
     - name: release_build_test
       working-directory: 
       run: |
-        apt update
-        apt install -y python3-wstool
+        
+        # apt update && apt install -y python3-wstool python3-catkin-tools 
         mkdir -p $HOME/catkin_ws/src;
         cd $HOME/catkin_ws
         catkin init

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,12 +1,13 @@
 name: Build Test
 on:
+  schedule:
+    - cron:  '30 18 * * *'
   push:
     branches:
     - 'master'
   pull_request:
     branches:
     - '*'
-
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # VersaVIS -- An Open Versatile Multi-Camera Visual-Inertial Sensor Suite
+[![Build Test](https://github.com/ethz-asl/versavis/actions/workflows/build_test.yml/badge.svg)](https://github.com/ethz-asl/versavis/actions/workflows/build_test.yml)
+
 VersaVIS provides a complete, open-source hardware, firmware and software bundle to perform time synchronization of multiple cameras with an IMU featuring exposure compensation, host clock translation and independent and stereo camera triggering.
 
 


### PR DESCRIPTION
**Problem Description**
This commit adds a simple build test for the following ROS versions
- ROS Melodic
- ROS Noetic

**Additional Context**
- The package doesn't seem to work with ROS Noetic yet from https://github.com/ethz-asl/versavis/issues/21, but the catkin package still builds.
