### PR TITLE
Run build test on self-hosted actions runner

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -10,7 +10,7 @@ on:
     - '*'
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This PR demonstrates that the build test runs on the self-hosted github actions runner on ibex.asl.ethz.ch